### PR TITLE
Bump authoritative version due to advisory

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,5 @@
 ---
 driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: 12.5.1
 
 platforms:
 - name: ubuntu-14.04

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Key                             | Type     | Description                        
 Key                                 | Type     | Description                                           | Default
 ------------------------------------| ---------|-------------------------------------------------------|---------
 `node['pdns']['source']['path']`    | String   | The base path to setting up the source installation   | /opt
-`node['pdns']['source']['version']` | String   | Version of source server or resolver based on 'flavor'| 3.4.7 or 3.7.3
+`node['pdns']['source']['version']` | String   | Version of source server or resolver based on 'flavor'| 3.4.10 or 3.7.3
 `node['pdns']['source']['url']`     | String   | URL to the PowerDNS Server Source Package             | https://downloads.powerdns.com/releases/pdns-[recursor?]-[version].tar.bz2
 
 ### package
@@ -77,7 +77,7 @@ Key                                                           | Type     | Descr
 `node['pdns']['slave']['config']['version_string']`           | String   | What powerdns answers when queried for its version over DNS       | powerdns
 `node['pdns']['slave']['config']['master']`                   | Boolean  | Operate in master mode                                            | false
 `node['pdns']['slave']['config']['slave']`                    | Boolean  | Operate as a slave to a PowerDNS master server                    | true
-`node['pdns']['authoritative']['config']['guardian']`        | Boolean  | Run within a guardian process                                    | true
+`node['pdns']['authoritative']['config']['guardian']`         | Boolean  | Run within a guardian process                                    | true
 `node['pdns']['slave']['config']['slave_cycle_interval']`     | String   | Seconds slave checks of domains with unknown status               | '60'
 `node['pdns']['slave']['config']['disable_axfr']`             | Boolean  | Do not allow zone transfers                                       | true
 
@@ -139,7 +139,7 @@ There are several combinations of backends and flavors available, currently a fe
  - Resolver                           (package and source)
  - Slave                              (package and source)
 
-## TODO
+## TODO
 
  - Add MySQL backend
  - Add SQLite backend

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,64 @@
+require 'cookstyle'
+require 'foodcritic'
+require 'kitchen'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
+# Style tests. Rubocop and Foodcritic
+namespace :style do
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:rubocop) do |t|
+    t.options << '--display-cop-names'
+  end
+
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
+    t.options = {
+      fail_tags: ['any']
+    }
+  end
+end
+
+namespace :unit do
+  # Rspec and ChefSpec
+  desc 'Run ChefSpec examples'
+  RSpec::Core::RakeTask.new(:chefspec) do |t|
+    t.rspec_opts = %w(
+      --color
+      --format progress
+    ).join(' ')
+  end
+end
+
+# Integration tests. Kitchen.ci
+desc 'Run Test Kitchen integration tests'
+namespace :integration do
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+end
+
+desc 'Travis and CI'
+namespace :cloud do
+  desc 'Run integration tests with kitchen-digitalocean via Travis-CI'
+  task :travis do
+    if ENV['TRAVIS'] == 'true'
+      sh "kitchen test #{ENV['KITCHEN_ARGS']} #{ENV['KITCHEN_REGEXP']}"
+    end
+  end
+end
+
+task style: %w( style:rubocop style:foodcritic )
+task unit: %w( unit:chefspec )
+task kitchen: %w( integration:kitchen:all )
+
+desc 'Run just the quick tests'
+task quick: %w( style unit )
+
+desc 'Run all tests on Travis'
+task travis: %w( style unit cloud:travis )
+
+desc 'All the tests, coffee time'
+task all: %w( style unit kitchen )
+
+# Default
+task default: 'all'

--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -21,5 +21,5 @@ default['pdns']['source']['path'] = '/opt'
 
 default['pdns']['recursor']['source']['version'] = '3.7.3'
 default['pdns']['recursor']['source']['url'] = 'https://downloads.powerdns.com/releases/pdns-recursor-3.7.3.tar.bz2'
-default['pdns']['authoritative']['source']['version'] = '3.4.7'
+default['pdns']['authoritative']['source']['version'] = '3.4.10'
 default['pdns']['authoritative']['source']['url'] = 'https://downloads.powerdns.com/releases/pdns-3.4.7.tar.bz2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,8 @@ license          'Apache 2.0'
 description      'Installs/Configures pdns'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.2.1'
-source_url       'https://github.com/aetrion/pdns' if respond_to?(:source_url)
-issues_url       'https://github.com/aetrion/pdns/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/dnsimple/pdns' if respond_to?(:source_url)
+issues_url       'https://github.com/dnsimple/pdns/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'


### PR DESCRIPTION
PowerDNS Security Advisory 2016-01: Crafted queries can cause unexpected backend load
CVE: CVE-2016-5426, CVE-2016-5427
https://doc.powerdns.com/md/security/powerdns-advisory-2016-01/

make some small documentation tweaks
add a rake file for testing
Remove old chef 12 version for testing